### PR TITLE
swingProcesser rewrite and more

### DIFF
--- a/Tech_Calculator/tech_calc.py
+++ b/Tech_Calculator/tech_calc.py
@@ -229,7 +229,10 @@ def processSwing(mapSplitData: list):
             cBlockA = reverseCutDirection(pBlockA)
         
         # It's considered a pattern if under 1/8 beat and same direction or if one of the two note is dot
-        if (cBlockB - pBlockB < 0.125 and (cBlockA == pBlockA or mapSplitData[i]['d'] == 8 or
+        # or if under 1/16
+        if cBlockB - pBlockB < 0.0625:
+            pattern = True
+        elif (cBlockB - pBlockB < 0.125 and (cBlockA == pBlockA or mapSplitData[i]['d'] == 8 or
                                           mapSplitData[i - 1]['d'] == 8)):
             pattern = True
         elif cBlockB - pBlockB < 0.5 and isSameDirection(pBlockA, cBlockA):  # Same direction under 1/2 beat

--- a/Tech_Calculator/tech_calc.py
+++ b/Tech_Calculator/tech_calc.py
@@ -575,7 +575,7 @@ def techOperations(mapData, bpm, isuser=True, verbose=True):
     staminaFactorRight = staminaCalc(RightSwingData)
     staminaFactor = max(staminaFactorLeft, staminaFactorRight)
 
-    balanced_pass = max(passDiffLeft * staminaFactorLeft, passDiffRight * staminaFactorRight)
+    balanced_pass = max(passDiffLeft * staminaFactorLeft, passDiffRight * staminaFactorRight) * 0.9
     balanced_tech = tech * (-1.4 ** (-passNum) + 1) * 10
 
     low_note_nerf = 1 / (1 + math.e**(-0.6 * (len(SwingData) / 100 + 1.5))) #https://www.desmos.com/calculator/povnzsoytj

--- a/Tech_Calculator/tech_calc.py
+++ b/Tech_Calculator/tech_calc.py
@@ -144,7 +144,7 @@ def fixPatternHead(mapSplitData: list):
                 if 0.02 >= mapSplitData[i]['b'] - mapSplitData[i - 1]['b'] >= -0.02:
                     if mapSplitData[i - 1]['d'] != 8:
                         temp = cut_direction_index[mapSplitData[i - 1]['d']] + mapSplitData[i - 1]['a']
-                elif 0.02 >= mapSplitData[i + 1]['b'] - mapSplitData[i]['b'] >= -0.02:
+                if 0.02 >= mapSplitData[i + 1]['b'] - mapSplitData[i]['b'] >= -0.02:
                     if mapSplitData[i + 1]['d'] != 8:
                         temp = cut_direction_index[mapSplitData[i + 1]['d']] + mapSplitData[i + 1]['a']
             if mapSplitData[i]['b'] == mapSplitData[i - 1]['b']:

--- a/Tech_Calculator/tech_calc.py
+++ b/Tech_Calculator/tech_calc.py
@@ -224,6 +224,10 @@ def processSwing(mapSplitData: list):
         cBlockB = mapSplitData[i]['b']
         cBlockA = cut_direction_index[mapSplitData[i]['d']] + mapSplitData[i]['a']
         cBlockP = [mapSplitData[i]['x'], mapSplitData[i]['y']]
+        
+        if mapSplitData[i]['d'] == 8:
+            cBlockA = reverseCutDirection(pBlockA)
+        
         # It's considered a pattern if under 1/4 beat and same direction or if one of the two note is dot
         if (cBlockB - pBlockB < 0.245 and (cBlockA == pBlockA or mapSplitData[i]['d'] == 8 or
                                           mapSplitData[i - 1]['d'] == 8)):

--- a/Tech_Calculator/tech_calc.py
+++ b/Tech_Calculator/tech_calc.py
@@ -569,7 +569,7 @@ def techOperations(mapData, bpm, isuser=True, verbose=True):
     
     passDiffLeft = diffToPass(LeftSwingData, bpm, 'left', isuser)
     passDiffRight = diffToPass(RightSwingData, bpm, 'right', isuser)
-    passNum = max(passDiffLeft, passDiffRight)
+    passNum = max(passDiffLeft, passDiffRight) * 0.9
 
     staminaFactorLeft = staminaCalc(LeftSwingData)
     staminaFactorRight = staminaCalc(RightSwingData)

--- a/Tech_Calculator/tech_calc.py
+++ b/Tech_Calculator/tech_calc.py
@@ -562,11 +562,16 @@ def techOperations(mapData, bpm, isuser=True, verbose=True):
     StrainList = [strain['angleStrain'] + strain['pathStrain'] for strain in SwingData]
     StrainList.sort()
     tech = average(StrainList[int(len(StrainList) * 0.25):])
-    passNum = max(diffToPass(LeftSwingData, bpm, 'left', isuser), diffToPass(RightSwingData, bpm, 'right', isuser))
+    
+    passDiffLeft = diffToPass(LeftSwingData, bpm, 'left', isuser)
+    passDiffRight = diffToPass(RightSwingData, bpm, 'right', isuser)
+    passNum = max(passDiffLeft, passDiffRight)
 
-    staminaFactor = max(staminaCalc(LeftSwingData), staminaCalc(RightSwingData))
-    balanced_pass = passNum * staminaFactor
+    staminaFactorLeft = staminaCalc(LeftSwingData)
+    staminaFactorRight = staminaCalc(RightSwingData)
+    staminaFactor = max(staminaFactorLeft, staminaFactorRight)
 
+    balanced_pass = max(passDiffLeft * staminaFactorLeft, passDiffRight * staminaFactorRight)
     balanced_tech = tech * (-1.4 ** (-passNum) + 1) * 10
 
     low_note_nerf = 1 / (1 + math.e**(-0.6 * (len(SwingData) / 100 + 1.5))) #https://www.desmos.com/calculator/povnzsoytj

--- a/Tech_Calculator/tech_calc.py
+++ b/Tech_Calculator/tech_calc.py
@@ -228,11 +228,11 @@ def processSwing(mapSplitData: list):
         if mapSplitData[i]['d'] == 8:
             cBlockA = reverseCutDirection(pBlockA)
         
-        # It's considered a pattern if under 1/4 beat and same direction or if one of the two note is dot
-        if (cBlockB - pBlockB < 0.245 and (cBlockA == pBlockA or mapSplitData[i]['d'] == 8 or
+        # It's considered a pattern if under 1/8 beat and same direction or if one of the two note is dot
+        if (cBlockB - pBlockB < 0.125 and (cBlockA == pBlockA or mapSplitData[i]['d'] == 8 or
                                           mapSplitData[i - 1]['d'] == 8)):
             pattern = True
-        elif cBlockB - pBlockB < 0.255 and isSameDirection(pBlockA, cBlockA):
+        elif cBlockB - pBlockB < 0.5 and isSameDirection(pBlockA, cBlockA):  # Same direction under 1/2 beat
             pattern = True
         else:
             pattern = False


### PR DESCRIPTION
- swingProcesser rewrite + pattern head detection to fix mirroring and reset issues
- Set Reset and Forehand at the same time to fix some issues
- Using Reset instead of Forehand to simulate hand position
- Removed distance -= 0.75 from swingCurveCalc. Nerfed balanced_pass by * 0.9 to compensate.
- Setting swingSpeed *= 2 instead of 1.5 just like in BL website atm
- Stamina and pass is now max of each hand instead of average
- Fixed some false reset detection
- Balanced_Tech * 10
- Cleanup